### PR TITLE
Improve Resume Experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Enhancements
 
 ### Bug Fixes
+- (frontend/resume) fixed playlist jumping on mobile Resume — playlist now starts on the saved track directly instead of playing track 0 first
+- (frontend/resume) fixed audio cutting out after seeking on mobile — removed programmatic `pause()` before seek to avoid triggering mobile interruption detection
+- (frontend/resume) fixed debug logs not appearing — switched from `window.debugLogger` fallback to proper ES module import; added `[Resume]` log points throughout the resume flow
+- (frontend/mobile) debounced `pause` and `waiting` event handlers in audio interruption detection to avoid false positives during brief seek operations
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - (frontend/resume) fixed playlist jumping on mobile Resume — playlist now starts on the saved track directly instead of playing track 0 first
 - (frontend/resume) fixed audio cutting out after seeking on mobile — removed programmatic `pause()` before seek to avoid triggering mobile interruption detection
 - (frontend/resume) fixed debug logs not appearing — switched from `window.debugLogger` fallback to proper ES module import; added `[Resume]` log points throughout the resume flow
-- (frontend/mobile) debounced `pause` and `waiting` event handlers in audio interruption detection to avoid false positives during brief seek operations
+- (frontend/mobile) debounced `pause`, `waiting`, and `stalled` event handlers in audio interruption detection to avoid false positives during seek and track loading; removed `suspend` as an interruption trigger since it fires constantly during normal buffering
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 ### Enhancements
 
 ### Bug Fixes
+- (frontend/resume) fixed audio starting from position 0 before seeking on mobile Resume — `startPosition` is now threaded through `loadPlaylistData` into `playTrack`, which seeks before calling `play()` so audio begins at the saved position with no audible gap
 - (frontend/resume) fixed playlist jumping on mobile Resume — playlist now starts on the saved track directly instead of playing track 0 first
-- (frontend/resume) fixed audio cutting out after seeking on mobile — removed programmatic `pause()` before seek to avoid triggering mobile interruption detection
 - (frontend/resume) fixed debug logs not appearing — switched from `window.debugLogger` fallback to proper ES module import; added `[Resume]` log points throughout the resume flow
 - (frontend/mobile) debounced `pause`, `waiting`, and `stalled` event handlers in audio interruption detection to avoid false positives during seek and track loading; removed `suspend` as an interruption trigger since it fires constantly during normal buffering
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,7 @@
 ### Enhancements
 
 ### Bug Fixes
-- (frontend/resume) fixed audio starting from position 0 before seeking on mobile Resume — `startPosition` is now threaded through `loadPlaylistData` into `playTrack`, which seeks before calling `play()` so audio begins at the saved position with no audible gap
-- (frontend/resume) fixed playlist jumping on mobile Resume — playlist now starts on the saved track directly instead of playing track 0 first
-- (frontend/resume) fixed debug logs not appearing — switched from `window.debugLogger` fallback to proper ES module import; added `[Resume]` log points throughout the resume flow
-- (frontend/mobile) debounced `pause`, `waiting`, and `stalled` event handlers in audio interruption detection to avoid false positives during seek and track loading; removed `suspend` as an interruption trigger since it fires constantly during normal buffering
+- (frontend/resume) fixed mobile Resume playing from the wrong track/position — playlist now loads directly on the saved track, seeks before `play()` is called, resulting in a much smoother Resume experience ([#55](https://github.com/isolinear-labs/Neosynth/pull/55))
 
 ### Docs
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -251,8 +251,8 @@ document.addEventListener('DOMContentLoaded', async function() {
     window.nowPlayingManager = nowPlayingManager;
 
     // Helper function to load playlist data (for compatibility with nowPlayingManager)
-    function loadPlaylistData(name, tracks, playlistId = null, startTrackIndex = null) {
-        playlistManager.loadPlaylistData(name, tracks, playlistId, startTrackIndex);
+    function loadPlaylistData(name, tracks, playlistId = null, startTrackIndex = null, startPosition = null) {
+        playlistManager.loadPlaylistData(name, tracks, playlistId, startTrackIndex, startPosition);
     }
 
     // Initialize feature manager first (needed by settings system)
@@ -813,26 +813,27 @@ document.addEventListener('DOMContentLoaded', async function() {
         }
     }
 	
-    // Play a track
-    function playTrack(index) {
+    // Play a track. Pass startPosition (seconds) to seek before playback begins,
+    // which avoids briefly playing from 0 on resume.
+    function playTrack(index, startPosition = null) {
         if (index < 0 || index >= playlist.length) return;
-		
+
         // Stop current playback
         stopPlayback();
-		
+
         currentTrackIndex = index;
         updatePlayHistory(currentTrackIndex);
         const track = playlist[currentTrackIndex];
-		
+
         // Update now playing info
         nowPlayingName.textContent = track.name;
-		
+
         // Show now playing container
         nowPlayingContainer.classList.remove('hide');
-		
+
         // Check file extension
         const fileExt = track.url.split('.').pop().toLowerCase();
-		
+
         // Setup the appropriate player
         if (['mp3', 'wav', 'ogg', 'flac', 'm4a', 'aac'].includes(fileExt)) {
             // Audio file
@@ -844,7 +845,7 @@ document.addEventListener('DOMContentLoaded', async function() {
             videoContainer.classList.add('hide'); // Hide first, then show if it has video
             videoPlayer.src = track.url;
             currentPlayer = videoPlayer;
-			
+
             // Check if it has video content
             videoPlayer.addEventListener('loadedmetadata', function videoCheck() {
                 try {
@@ -862,23 +863,40 @@ document.addEventListener('DOMContentLoaded', async function() {
                 videoPlayer.removeEventListener('loadedmetadata', videoCheck);
             });
         }
-		
+
         // Set volume
         currentPlayer.volume = volumeSlider.value / 100;
-		
-        // Start playing
-        currentPlayer.play()
-            .then(() => {
-                isPlaying = true;
-                playPauseBtn.textContent = '⏸';
-                renderPlaylist();
-                
-                // Record play in shuffle manager
-                shuffleManager.recordPlay(track.url, track.name);
-            })
-            .catch(error => {
-                showStatus(`Error playing track: ${error.message}`, true);
-            });
+
+        const doPlay = () => {
+            currentPlayer.play()
+                .then(() => {
+                    isPlaying = true;
+                    playPauseBtn.textContent = '⏸';
+                    renderPlaylist();
+
+                    // Record play in shuffle manager
+                    shuffleManager.recordPlay(track.url, track.name);
+                })
+                .catch(error => {
+                    showStatus(`Error playing track: ${error.message}`, true);
+                });
+        };
+
+        if (startPosition !== null && startPosition > 0) {
+            // Seek before playing so audio never starts from position 0
+            const seekThenPlay = () => {
+                currentPlayer.currentTime = startPosition;
+                currentPlayer.removeEventListener('loadedmetadata', seekThenPlay);
+                doPlay();
+            };
+            if (currentPlayer.readyState >= 1) {
+                seekThenPlay();
+            } else {
+                currentPlayer.addEventListener('loadedmetadata', seekThenPlay);
+            }
+        } else {
+            doPlay();
+        }
     }
 	
     // Stop current playback

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -251,9 +251,8 @@ document.addEventListener('DOMContentLoaded', async function() {
     window.nowPlayingManager = nowPlayingManager;
 
     // Helper function to load playlist data (for compatibility with nowPlayingManager)
-    function loadPlaylistData(name, tracks, playlistId = null) {
-        // Use the playlist manager's loadPlaylistData method
-        playlistManager.loadPlaylistData(name, tracks, playlistId);
+    function loadPlaylistData(name, tracks, playlistId = null, startTrackIndex = null) {
+        playlistManager.loadPlaylistData(name, tracks, playlistId, startTrackIndex);
     }
 
     // Initialize feature manager first (needed by settings system)

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -299,8 +299,7 @@ document.addEventListener('DOMContentLoaded', async function() {
         appCallbacks: {
             addTrack: addTrack,
             getCurrentPlayer: () => currentPlayer,
-            loadPlaylistData: loadPlaylistData,
-            playTrack: playTrack
+            loadPlaylistData: loadPlaylistData
         }
     });
 

--- a/frontend/modules/mobile/audioInterruption.js
+++ b/frontend/modules/mobile/audioInterruption.js
@@ -64,12 +64,23 @@ export class AudioInterruptionManager {
 
         // Handle native audio interruption events
         if (audioPlayer) {
+            // Debounce pause/waiting detection - programmatic pauses (e.g. seek) are brief and
+            // should not be treated as external interruptions. Only fire if still paused after 800ms.
             audioPlayer.addEventListener('pause', (_e) => {
-                // Check if this pause was programmatic or due to interruption
                 if (!this.isHandlingInterruption && this.appElements.isPlaying) {
-                    debug.log('Audio paused unexpectedly - possible interruption');
-                    this.handleAudioInterruption();
+                    clearTimeout(this._pauseInterruptionTimer);
+                    this._pauseInterruptionTimer = setTimeout(() => {
+                        if (this.appElements.currentPlayer?.paused && this.appElements.isPlaying && !this.isHandlingInterruption) {
+                            debug.log('Audio paused unexpectedly - possible interruption');
+                            this.handleAudioInterruption();
+                        }
+                    }, 800);
                 }
+            });
+
+            // Clear the debounce timer when playback resumes (seek complete)
+            audioPlayer.addEventListener('play', () => {
+                clearTimeout(this._pauseInterruptionTimer);
             });
 
             audioPlayer.addEventListener('stalled', () => {
@@ -83,11 +94,21 @@ export class AudioInterruptionManager {
             });
 
             audioPlayer.addEventListener('waiting', () => {
-                // Only treat as interruption if we were playing
+                // Only treat as interruption if we were playing and not mid-seek
                 if (this.appElements.isPlaying && !this.isInterrupted) {
-                    debug.log('Audio waiting - possible interruption');
-                    this.handleAudioInterruption();
+                    clearTimeout(this._waitingInterruptionTimer);
+                    this._waitingInterruptionTimer = setTimeout(() => {
+                        if (this.appElements.isPlaying && !this.isInterrupted && !this.isHandlingInterruption) {
+                            debug.log('Audio waiting - possible interruption');
+                            this.handleAudioInterruption();
+                        }
+                    }, 800);
                 }
+            });
+
+            // Clear waiting timer when playback resumes
+            audioPlayer.addEventListener('playing', () => {
+                clearTimeout(this._waitingInterruptionTimer);
             });
         }
 
@@ -95,9 +116,18 @@ export class AudioInterruptionManager {
             // Similar handlers for video player
             videoPlayer.addEventListener('pause', (_e) => {
                 if (!this.isHandlingInterruption && this.appElements.isPlaying) {
-                    debug.log('Video paused unexpectedly - possible interruption');
-                    this.handleAudioInterruption();
+                    clearTimeout(this._videoPauseInterruptionTimer);
+                    this._videoPauseInterruptionTimer = setTimeout(() => {
+                        if (this.appElements.currentPlayer?.paused && this.appElements.isPlaying && !this.isHandlingInterruption) {
+                            debug.log('Video paused unexpectedly - possible interruption');
+                            this.handleAudioInterruption();
+                        }
+                    }, 800);
                 }
+            });
+
+            videoPlayer.addEventListener('play', () => {
+                clearTimeout(this._videoPauseInterruptionTimer);
             });
         }
     }

--- a/frontend/modules/mobile/audioInterruption.js
+++ b/frontend/modules/mobile/audioInterruption.js
@@ -83,15 +83,22 @@ export class AudioInterruptionManager {
                 clearTimeout(this._pauseInterruptionTimer);
             });
 
+            // stalled = browser can't get data - debounce since it can fire during normal
+            // track loading/source changes before data arrives
             audioPlayer.addEventListener('stalled', () => {
-                debug.log('Audio stalled - possible interruption');
-                this.handleAudioInterruption();
+                if (this.appElements.isPlaying && !this.isInterrupted) {
+                    clearTimeout(this._stalledInterruptionTimer);
+                    this._stalledInterruptionTimer = setTimeout(() => {
+                        if (this.appElements.isPlaying && !this.isInterrupted && !this.isHandlingInterruption) {
+                            debug.log('Audio stalled - possible interruption');
+                            this.handleAudioInterruption();
+                        }
+                    }, 3000);
+                }
             });
 
-            audioPlayer.addEventListener('suspend', () => {
-                debug.log('Audio suspended - possible interruption');
-                this.handleAudioInterruption();
-            });
+            // suspend fires constantly during normal buffering (browser stops pre-fetching) -
+            // it is NOT a reliable indicator of an external interruption, so we ignore it here
 
             audioPlayer.addEventListener('waiting', () => {
                 // Only treat as interruption if we were playing and not mid-seek
@@ -106,8 +113,9 @@ export class AudioInterruptionManager {
                 }
             });
 
-            // Clear waiting timer when playback resumes
+            // Clear all debounce timers when playback actually resumes
             audioPlayer.addEventListener('playing', () => {
+                clearTimeout(this._stalledInterruptionTimer);
                 clearTimeout(this._waitingInterruptionTimer);
             });
         }

--- a/frontend/modules/mobile/mobileOptimizations.js
+++ b/frontend/modules/mobile/mobileOptimizations.js
@@ -95,10 +95,10 @@ export class MobileOptimizations {
     wrapPlaybackFunctions() {
         // Wrap playTrack to handle interruptions
         const originalPlayTrack = this.appElements.playTrack;
-        this.appElements.playTrack = async (index) => {
+        this.appElements.playTrack = async (index, ...args) => {
             // Reset interruption state when playing a new track
             this.audioInterruption.isInterrupted = false;
-            return originalPlayTrack.call(this, index);
+            return originalPlayTrack.call(this, index, ...args);
         };
 
         // Wrap play functions to use interruption recovery

--- a/frontend/modules/nowPlaying/nowPlaying.js
+++ b/frontend/modules/nowPlaying/nowPlaying.js
@@ -53,15 +53,15 @@ export class NowPlaying {
     
         // Skip if no user ID or no current track
         if (!this.userId || this.appElements.currentTrackIndex < 0) {
-            console.log('Skipping save - no userID or current track', 
+            debug.log('Skipping nowPlaying save - no userID or current track',
                 { userId: this.userId, currentTrackIndex: this.appElements.currentTrackIndex });
             return;
         }
-		
+
         // Throttle saves to avoid too many requests
         const now = Date.now();
         if (now - this.lastSaveTime < this.saveThrottleMs) {
-            console.log('Skipping save - throttled');
+            debug.log('Skipping nowPlaying save - throttled');
             return;
         }
 		

--- a/frontend/modules/playlist/playlistManager.js
+++ b/frontend/modules/playlist/playlistManager.js
@@ -302,28 +302,28 @@ export class PlaylistManager {
 	 * @param {Array} tracks - Array of tracks
 	 * @param {string} playlistId - Optional playlist ID
 	 */
-    loadPlaylistData(name, tracks, playlistId = null) {
+    loadPlaylistData(name, tracks, playlistId = null, startTrackIndex = null) {
         // Stop current playback
         if (this.appElements.stopPlayback) {
             this.appElements.stopPlayback();
         }
-		
+
         // Update playlist
         this.appElements.playlist.length = 0;
         this.appElements.playlist.push(...tracks);
         this.appElements.playlist.playlistId = playlistId;
         this.appElements.currentTrackIndex = -1;
-		
+
         // Update play history if it exists
         if (this.appElements.updatePlayHistory) {
             this.appElements.updatePlayHistory(this.appElements.currentTrackIndex);
         }
-		
+
         // Update volume multiplier display and apply to player for new playlist
         if (window.volumeMultiplierManager && window.volumeMultiplierManager.isInitialized) {
             window.volumeMultiplierManager.onTrackChange();
         }
-		
+
         // Re-render playlist and update counter
         if (this.appElements.renderPlaylist) {
             this.appElements.renderPlaylist();
@@ -331,21 +331,23 @@ export class PlaylistManager {
         if (this.appElements.updateTrackCounter) {
             this.appElements.updateTrackCounter();
         }
-		
+
         // Start playing if there are tracks
         if (this.appElements.playlist.length > 0) {
-            // If shuffle is enabled, choose a random track to start with
             let startIndex = 0;
-            if (this.appElements.isShuffleEnabled && this.appElements.shuffleState && 
-				this.appElements.shuffleState.value && this.appElements.playlist.length > 1) {
+            if (startTrackIndex !== null && startTrackIndex >= 0 && startTrackIndex < this.appElements.playlist.length) {
+                // Caller specified a starting track (e.g. resume to saved track)
+                startIndex = startTrackIndex;
+            } else if (this.appElements.isShuffleEnabled && this.appElements.shuffleState &&
+                this.appElements.shuffleState.value && this.appElements.playlist.length > 1) {
                 startIndex = Math.floor(Math.random() * this.appElements.playlist.length);
             }
-			
+
             if (this.appElements.playTrack) {
                 this.appElements.playTrack(startIndex);
             }
         }
-		
+
         // Update playlist name input
         this.playlistNameInput.value = name;
         this.showStatus(`Loaded playlist: "${name}"`);

--- a/frontend/modules/playlist/playlistManager.js
+++ b/frontend/modules/playlist/playlistManager.js
@@ -302,7 +302,7 @@ export class PlaylistManager {
 	 * @param {Array} tracks - Array of tracks
 	 * @param {string} playlistId - Optional playlist ID
 	 */
-    loadPlaylistData(name, tracks, playlistId = null, startTrackIndex = null) {
+    loadPlaylistData(name, tracks, playlistId = null, startTrackIndex = null, startPosition = null) {
         // Stop current playback
         if (this.appElements.stopPlayback) {
             this.appElements.stopPlayback();
@@ -344,7 +344,7 @@ export class PlaylistManager {
             }
 
             if (this.appElements.playTrack) {
-                this.appElements.playTrack(startIndex);
+                this.appElements.playTrack(startIndex, startPosition);
             }
         }
 

--- a/frontend/modules/restoreTrack/restoreTrackManager.js
+++ b/frontend/modules/restoreTrack/restoreTrackManager.js
@@ -1,5 +1,5 @@
 // Restore Track Manager - Expandable button for resuming last played track
-const debug = window.debugLogger || { log: () => {}, info: () => {} };
+import debug from '../debugLogger/debugLogger.js';
 
 class RestoreTrackManager {
     constructor() {
@@ -136,88 +136,38 @@ class RestoreTrackManager {
             return;
         }
 
+        debug.log('[Resume] Starting resume - track:', this.resumeData.trackName, '| position:', this.resumeData.position);
+
         try {
             // If we have a playlist ID, restore the full playlist
             if (this.resumeData.playListId && this.appCallbacks.loadPlaylistData) {
+                debug.log('[Resume] Fetching playlist:', this.resumeData.playListId);
                 const playlistResponse = await this.apiCall(`/api/playlists/detail/${this.resumeData.playListId}`);
-                
+
                 if (playlistResponse && playlistResponse.ok) {
                     const playlistData = await playlistResponse.json();
-                    
-                    // Load the full playlist
-                    this.appCallbacks.loadPlaylistData(playlistData.name, playlistData.tracks, playlistData._id);
-                    
-                    // Find the track index by URL
+                    debug.log('[Resume] Playlist loaded:', playlistData.name, '|', playlistData.tracks.length, 'tracks');
+
+                    // Find the track index BEFORE loading the playlist so we can start on the right track
                     const trackIndex = playlistData.tracks.findIndex(track => track.url === this.resumeData.trackUrl);
-                    
-                    if (trackIndex >= 0 && this.appCallbacks.playTrack) {
-                        // Wait a moment for stopPlayback() to complete, then play the track
-                        setTimeout(() => {
-                            // Play the track - it will auto-start
-                            this.appCallbacks.playTrack(trackIndex);
+                    debug.log('[Resume] Track index in playlist:', trackIndex, '| URL:', this.resumeData.trackUrl);
 
-                            // Wait for player to initialize and start playing
-                            const waitForPlayerAndSeek = () => {
-                                const player = this.appCallbacks.getCurrentPlayer();
-                                if (!player) {
-                                    setTimeout(waitForPlayerAndSeek, 50);
-                                    return;
-                                }
+                    if (trackIndex >= 0 && this.appCallbacks.loadPlaylistData) {
+                        // Load playlist starting directly on the saved track - avoids jumping from track 0
+                        this.appCallbacks.loadPlaylistData(playlistData.name, playlistData.tracks, playlistData._id, trackIndex);
 
-                                // Wait for the media to be ready before seeking
-                                const seekToPosition = () => {
-                                    if (player.readyState >= 2) { // HAVE_CURRENT_DATA or higher
-                                        // Pause first to avoid the "operation aborted" error
-                                        player.pause();
-
-                                        // Then seek to saved position
-                                        if (typeof this.resumeData.position === 'number') {
-                                            player.currentTime = this.resumeData.position;
-                                        }
-
-                                        // Apply volume multiplier after resuming
-                                        if (window.volumeMultiplierManager && window.volumeMultiplierManager.isInitialized) {
-                                            window.volumeMultiplierManager.onTrackChange();
-                                        }
-
-                                        // Resume playback
-                                        player.play().catch(e => debug.log('Play interrupted:', e));
-                                    } else {
-                                        // Wait for loadeddata event
-                                        const onLoadedData = () => {
-                                            player.pause();
-
-                                            if (typeof this.resumeData.position === 'number') {
-                                                player.currentTime = this.resumeData.position;
-                                            }
-
-                                            // Apply volume multiplier after resuming
-                                            if (window.volumeMultiplierManager && window.volumeMultiplierManager.isInitialized) {
-                                                window.volumeMultiplierManager.onTrackChange();
-                                            }
-
-                                            player.play().catch(e => debug.log('Play interrupted:', e));
-                                            player.removeEventListener('loadeddata', onLoadedData);
-                                        };
-                                        player.addEventListener('loadeddata', onLoadedData);
-                                    }
-                                };
-
-                                seekToPosition();
-                            };
-
-                            waitForPlayerAndSeek();
-                        }, 300);
+                        // Seek to saved position once the player is ready
+                        this._waitAndSeek();
                     } else {
-                        // Track not found in playlist, fall back to single track
+                        debug.log('[Resume] Track not found in playlist, falling back to single track');
                         await this.fallbackToSingleTrack();
                     }
                 } else {
-                    // Playlist not found, fall back to single track
+                    debug.log('[Resume] Playlist fetch failed, falling back to single track');
                     await this.fallbackToSingleTrack();
                 }
             } else {
-                // No playlist ID, just play the single track
+                debug.log('[Resume] No playlist ID, playing single track');
                 await this.fallbackToSingleTrack();
             }
 
@@ -225,69 +175,63 @@ class RestoreTrackManager {
             this.container.style.display = 'none';
 
         } catch (error) {
-            console.error('Error resuming playback:', error);
+            console.error('[Resume] Error resuming playback:', error);
             // Fall back to single track on any error
             await this.fallbackToSingleTrack();
         }
     }
 
+    // Wait for the player to be available and ready, then seek to saved position
+    _waitAndSeek() {
+        const position = this.resumeData.position;
+        if (typeof position !== 'number' || position <= 0) {
+            debug.log('[Resume] No seek needed (position:', position, ')');
+            return;
+        }
+
+        debug.log('[Resume] Waiting for player to seek to', position);
+
+        const waitForPlayer = () => {
+            const player = this.appCallbacks.getCurrentPlayer();
+            if (!player) {
+                setTimeout(waitForPlayer, 50);
+                return;
+            }
+
+            const doSeek = () => {
+                debug.log('[Resume] Seeking to', position, '| readyState:', player.readyState);
+                // Set currentTime directly while playing - no pause() needed and avoids
+                // triggering the mobile audio interruption detection
+                player.currentTime = position;
+
+                if (window.volumeMultiplierManager && window.volumeMultiplierManager.isInitialized) {
+                    window.volumeMultiplierManager.onTrackChange();
+                }
+            };
+
+            if (player.readyState >= 2) {
+                doSeek();
+            } else {
+                debug.log('[Resume] Player not ready (readyState:', player.readyState, '), waiting for canplay');
+                const onCanPlay = () => {
+                    player.removeEventListener('canplay', onCanPlay);
+                    doSeek();
+                };
+                player.addEventListener('canplay', onCanPlay);
+            }
+        };
+
+        waitForPlayer();
+    }
+
     async fallbackToSingleTrack() {
-        // Fallback: just add the single track
+        debug.log('[Resume] Fallback: adding single track:', this.resumeData.trackUrl);
         if (this.appCallbacks.addTrack) {
             const success = await this.appCallbacks.addTrack(this.resumeData.trackUrl);
+            debug.log('[Resume] addTrack result:', success);
 
-            if (success && this.appCallbacks.getCurrentPlayer) {
-                // Wait for player to initialize and start playing
-                const waitForPlayerAndSeek = () => {
-                    const player = this.appCallbacks.getCurrentPlayer();
-                    if (!player) {
-                        setTimeout(waitForPlayerAndSeek, 50);
-                        return;
-                    }
-
-                    // Wait for the media to be ready before seeking
-                    const seekToPosition = () => {
-                        if (player.readyState >= 2) { // HAVE_CURRENT_DATA or higher
-                            // Pause first to avoid the "operation aborted" error
-                            player.pause();
-
-                            // Then seek to saved position
-                            if (typeof this.resumeData.position === 'number') {
-                                player.currentTime = this.resumeData.position;
-                            }
-
-                            // Apply volume multiplier after resuming
-                            if (window.volumeMultiplierManager && window.volumeMultiplierManager.isInitialized) {
-                                window.volumeMultiplierManager.onTrackChange();
-                            }
-
-                            // Resume playback
-                            player.play().catch(e => debug.log('Play interrupted:', e));
-                        } else {
-                            // Wait for loadeddata event
-                            const onLoadedData = () => {
-                                player.pause();
-
-                                if (typeof this.resumeData.position === 'number') {
-                                    player.currentTime = this.resumeData.position;
-                                }
-
-                                // Apply volume multiplier after resuming
-                                if (window.volumeMultiplierManager && window.volumeMultiplierManager.isInitialized) {
-                                    window.volumeMultiplierManager.onTrackChange();
-                                }
-
-                                player.play().catch(e => debug.log('Play interrupted:', e));
-                                player.removeEventListener('loadeddata', onLoadedData);
-                            };
-                            player.addEventListener('loadeddata', onLoadedData);
-                        }
-                    };
-
-                    seekToPosition();
-                };
-
-                waitForPlayerAndSeek();
+            if (success) {
+                this._waitAndSeek();
             }
         }
     }

--- a/frontend/modules/restoreTrack/restoreTrackManager.js
+++ b/frontend/modules/restoreTrack/restoreTrackManager.js
@@ -153,11 +153,12 @@ class RestoreTrackManager {
                     debug.log('[Resume] Track index in playlist:', trackIndex, '| URL:', this.resumeData.trackUrl);
 
                     if (trackIndex >= 0 && this.appCallbacks.loadPlaylistData) {
-                        // Load playlist starting directly on the saved track - avoids jumping from track 0
-                        this.appCallbacks.loadPlaylistData(playlistData.name, playlistData.tracks, playlistData._id, trackIndex);
-
-                        // Seek to saved position once the player is ready
-                        this._waitAndSeek();
+                        // Load playlist starting on the saved track at the saved position.
+                        // startPosition is passed into playTrack so the seek happens before
+                        // play() is called — no audible playback from position 0.
+                        const savedPosition = typeof this.resumeData.position === 'number' ? this.resumeData.position : null;
+                        debug.log('[Resume] Loading playlist with startTrackIndex:', trackIndex, '| startPosition:', savedPosition);
+                        this.appCallbacks.loadPlaylistData(playlistData.name, playlistData.tracks, playlistData._id, trackIndex, savedPosition);
                     } else {
                         debug.log('[Resume] Track not found in playlist, falling back to single track');
                         await this.fallbackToSingleTrack();


### PR DESCRIPTION
## Description
When navigating to the Resume feature, especially on mobile, tracks will switch for a moment from the first track in a playlist to the expected track - causing a disruption in play. This PR addresses this behavior by loading the expected seek playlist time prior to the player trying to play. 

## Reason for PR
- [ ] New feature
- [ ] Enhancement
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring

## Breaking change?
- [ ] Yes

## User Impact & Considerations
<!-- Describe any potential user impact or items that other should be aware of -->

<!-- You may remove the below options if deemed unessary -->

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Related Issue (if applicable)
<!-- Use keywords to auto-close: Closes #123, Fixes #456, Resolves #789 -->
<!-- Or just reference: Related to #123, See #456 -->

