### PR TITLE
Mobile player rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@
 ## [Unreleased]
 
 ### Enhancements
+- feat(frontend/mobile): Revamped iOS background audio controls: pause now works on first press, play reliably resumes and pauses. This allows external audio control devices, such as airpods, to correctly push commands to the player ([#56](https://github.com/isolinear-labs/Neosynth/pull/56))
 
 ### Bug Fixes
-- (frontend/resume) fixed mobile Resume playing from the wrong track/position — playlist now loads directly on the saved track, seeks before `play()` is called, resulting in a much smoother Resume experience ([#55](https://github.com/isolinear-labs/Neosynth/pull/55))
+- fix(frontend/resume) fixed mobile Resume playing from the wrong track/position — playlist now loads directly on the saved track, seeks before `play()` is called, resulting in a much smoother Resume experience ([#55](https://github.com/isolinear-labs/Neosynth/pull/55))
 
 ### Docs
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -928,9 +928,9 @@ document.addEventListener('DOMContentLoaded', async function() {
         if (!currentPlayer || currentTrackIndex < 0) return;
 		
         if (isPlaying) {
-            currentPlayer.pause();
             isPlaying = false;
             playPauseBtn.textContent = '▶';
+            currentPlayer.pause();
         } else {
             currentPlayer.play()
                 .then(() => {

--- a/frontend/modules/mobile/appElementsFactory.js
+++ b/frontend/modules/mobile/appElementsFactory.js
@@ -27,9 +27,20 @@ export function createAppElements(appScope) {
         }
     }
 	
-    // Extract variables from app scope
+    // Extract variables from app scope as live getters/setters so that
+    // changes made in app.js (e.g. isPlaying, currentPlayer) are immediately
+    // visible to all mobile modules, and writes from mobile modules propagate
+    // back to the app without the two copies diverging.
     for (const variableName of APP_ELEMENTS_CONFIG.variables) {
-        if (appScope[variableName] !== undefined) {
+        const descriptor = Object.getOwnPropertyDescriptor(appScope, variableName);
+        if (descriptor && (descriptor.get || descriptor.set)) {
+            Object.defineProperty(appElements, variableName, {
+                get: () => appScope[variableName],
+                set: (v) => { appScope[variableName] = v; },
+                enumerable: true,
+                configurable: true
+            });
+        } else if (appScope[variableName] !== undefined) {
             appElements[variableName] = appScope[variableName];
         } else {
             console.warn(`Variable '${variableName}' not found in app scope`);

--- a/frontend/modules/mobile/audioInterruption.js
+++ b/frontend/modules/mobile/audioInterruption.js
@@ -50,18 +50,6 @@ export class AudioInterruptionManager {
             document.addEventListener('click', resumeAudioContext);
         }
 
-        // Handle media session interruptions
-        if ('mediaSession' in navigator) {
-            // These events help detect when another app takes control
-            navigator.mediaSession.setActionHandler('pause', () => {
-                debug.log('Media session pause detected');
-                this.handleAudioInterruption();
-                if (this.appElements.togglePlayPause) {
-                    this.appElements.togglePlayPause();
-                }
-            });
-        }
-
         // Handle native audio interruption events
         if (audioPlayer) {
             // Debounce pause/waiting detection - programmatic pauses (e.g. seek) are brief and
@@ -142,21 +130,26 @@ export class AudioInterruptionManager {
 
     // Enhanced audio context handling
     setupAudioContextHandling() {
-        // Create a global audio context monitor
+        // Resume suspended audio context on user interaction so the first tap
+        // after a page load or interruption doesn't silently fail.
         if (typeof AudioContext !== 'undefined' || typeof webkitAudioContext !== 'undefined') {
-            const _AudioContextClass = AudioContext || webkitAudioContext;
-			
-            // Create a monitor that checks audio context state
-            setInterval(() => {
-                if (this.appElements.currentPlayer && this.appElements.isPlaying) {
-                    // Check if audio is actually playing
-                    if (this.appElements.currentPlayer.paused && !this.isInterrupted) {
-                        debug.log('Detected audio is paused while state says playing');
-                        this.handleAudioInterruption();
-                    }
+            const AudioContextClass = AudioContext || webkitAudioContext;
+            const resumeCtx = () => {
+                const ctx = new AudioContextClass();
+                if (ctx.state === 'suspended') {
+                    ctx.resume().catch(err => debug.log('Failed to resume audio context:', err));
                 }
-            }, 1000);
+            };
+            document.addEventListener('touchstart', resumeCtx, { once: true });
+            document.addEventListener('click', resumeCtx, { once: true });
         }
+        // NOTE: The 1-second polling interval that previously called
+        // handleAudioInterruption() when currentPlayer.paused was true has been
+        // removed. It produced false positives during normal buffering pauses
+        // (now that currentPlayer is a live reference), stomping isPlaying=false
+        // while audio was still running and making lock-screen pause require two
+        // presses. Genuine interruptions are already handled by the debounced
+        // 'pause' event listener in setupInterruptionHandlers().
     }
 
     // Handle page visibility changes

--- a/frontend/modules/mobile/mediaSession.js
+++ b/frontend/modules/mobile/mediaSession.js
@@ -20,57 +20,51 @@ export class MediaSessionManager {
     }
 
     // Set up media session action handlers
+    // Uses live this.appElements references so that any function wrapping applied
+    // by mobileOptimizations after init is automatically picked up.
     setupActionHandlers() {
-        const {
-            togglePlayPause,
-            playNext,
-            playPrevious,
-            stopPlayback
-        } = this.appElements;
-
-
         if (this.isMobile) {
-            // Mobile: Use state-aware handlers
+            // Mobile: state-aware handlers prevent double-toggle on iOS
             navigator.mediaSession.setActionHandler('play', () => {
-                if (togglePlayPause && !this.appElements.isPlaying) {
-                    togglePlayPause();
+                if (this.appElements.togglePlayPause && !this.appElements.isPlaying) {
+                    this.appElements.togglePlayPause();
                 }
             });
 
             navigator.mediaSession.setActionHandler('pause', () => {
-                if (togglePlayPause && this.appElements.isPlaying) {
-                    togglePlayPause();
+                if (this.appElements.togglePlayPause && this.appElements.isPlaying) {
+                    this.appElements.togglePlayPause();
                 }
             });
 
-            // Set seek handlers to forward to next/previous track on mobile
-            navigator.mediaSession.setActionHandler('seekbackward', () => {
-                if (playPrevious) playPrevious();
-            });
-            navigator.mediaSession.setActionHandler('seekforward', () => {
-                if (playNext) playNext();
-            });
+            // Unregister seek handlers so iOS shows nexttrack/previoustrack instead.
+            // iOS will hide next/prev when seek handlers are registered — choose one or the other.
+            // To switch to +/-10s seek buttons replace these with:
+            //   ('seekbackward', (d) => { const s = d.seekOffset || 10; if (this.appElements.currentPlayer) this.appElements.currentPlayer.currentTime = Math.max(0, this.appElements.currentPlayer.currentTime - s); });
+            //   ('seekforward',  (d) => { const s = d.seekOffset || 10; if (this.appElements.currentPlayer) this.appElements.currentPlayer.currentTime = Math.min(this.appElements.currentPlayer.duration || 0, this.appElements.currentPlayer.currentTime + s); });
+            navigator.mediaSession.setActionHandler('seekbackward', null);
+            navigator.mediaSession.setActionHandler('seekforward', null);
         } else {
-            // Desktop: Use toggle for both (existing working behavior)
+            // Desktop: toggle for both (existing working behavior)
             navigator.mediaSession.setActionHandler('play', () => {
-                if (togglePlayPause) togglePlayPause();
+                if (this.appElements.togglePlayPause) this.appElements.togglePlayPause();
             });
 
             navigator.mediaSession.setActionHandler('pause', () => {
-                if (togglePlayPause) togglePlayPause();
+                if (this.appElements.togglePlayPause) this.appElements.togglePlayPause();
             });
         }
 
         navigator.mediaSession.setActionHandler('nexttrack', () => {
-            if (playNext) playNext();
+            if (this.appElements.playNext) this.appElements.playNext();
         });
 
         navigator.mediaSession.setActionHandler('previoustrack', () => {
-            if (playPrevious) playPrevious();
+            if (this.appElements.playPrevious) this.appElements.playPrevious();
         });
 
         navigator.mediaSession.setActionHandler('stop', () => {
-            if (stopPlayback) stopPlayback();
+            if (this.appElements.stopPlayback) this.appElements.stopPlayback();
         });
     }
 
@@ -133,19 +127,12 @@ export class MediaSessionManager {
 
         navigator.mediaSession.metadata = metadata;
         this.currentMetadata = metadata;
-        
-        
-        // Mobile-specific: Re-establish handlers to prevent grayed out buttons
-        if (this.isMobile) {
-            const { playNext, playPrevious } = this.appElements;
-            
-            navigator.mediaSession.setActionHandler('nexttrack', () => {
-                if (playNext) playNext();
-            });
 
-            navigator.mediaSession.setActionHandler('previoustrack', () => {
-                if (playPrevious) playPrevious();
-            });
+        // Re-establish all handlers on every metadata update — iOS can silently
+        // drop registered handlers when metadata changes, causing the lock screen
+        // controls to route to another app (e.g. Apple Music) instead.
+        if (this.isMobile) {
+            this.setupActionHandlers();
         }
     }
 

--- a/frontend/modules/mobile/mobileOptimizations.js
+++ b/frontend/modules/mobile/mobileOptimizations.js
@@ -49,11 +49,13 @@ export class MobileOptimizations {
         const _originalTogglePlayPause = this.appElements.togglePlayPause;
         this.appElements.togglePlayPause = async () => {
             if (this.appElements.isPlaying) {
-                // Just pause normally
+                // Set state before calling pause() so the 'pause' event fires
+                // with isPlaying already false — prevents the debounce in
+                // audioInterruption from treating this as an OS interruption.
                 if (this.appElements.currentPlayer) {
-                    this.appElements.currentPlayer.pause();
                     this.appElements.isPlaying = false;
                     this.appElements.playPauseBtn.textContent = '▶';
+                    this.appElements.currentPlayer.pause();
                 }
             } else {
                 // Try to play with interruption recovery
@@ -82,13 +84,11 @@ export class MobileOptimizations {
         document.addEventListener('touchstart', resumeAudioOnInteraction, { once: true });
         document.addEventListener('click', resumeAudioOnInteraction, { once: true });
 
-        // Periodically check if audio is actually playing on iOS
-        setInterval(() => {
-            if (this.appElements.isPlaying && !this.audioInterruption.isAudioActuallyPlaying()) {
-                debug.log('iOS: Detected audio stopped playing unexpectedly');
-                this.audioInterruption.handleAudioInterruption();
-            }
-        }, 2000);
+        // NOTE: The 2-second polling interval for isAudioActuallyPlaying() has
+        // been removed for the same reason as the 1-second interval in
+        // audioInterruption — it triggered false positives during buffering pauses
+        // now that currentPlayer/isPlaying are live references, leaving isPlaying
+        // wrongly false and making the lock-screen pause unresponsive.
     }
 
     // Wrap playback functions to handle interruptions


### PR DESCRIPTION
## Description
Mobile media controls have been rewritten. The Play / Resume buttons now respond to the first click & the Next / Previous buttons now correctly navigate to the next track. These updated controls should also be effective with external controls, such as AirPods. 

## Reason for PR
- [ ] New feature
- [x] Enhancement
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring

## Breaking change?
- [ ] Yes

## User Impact & Considerations
Users may need to delete cache / wait for cache to expire to see this changes come into play. 