### PR TITLE
Docker/version injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Enhancements
+- (docker) added `APP_VERSION` and `BUILD_STATUS` build args to stamp `constants.js` at image build time — pass `BUILD_STATUS=$(git rev-parse --short HEAD)` to identify the exact build running in the PWA
 
 ### Bug Fixes
 - (frontend/resume) fixed mobile Resume playing from the wrong track/position — playlist now loads directly on the saved track, seeks before `play()` is called, resulting in a much smoother Resume experience ([#55](https://github.com/isolinear-labs/Neosynth/pull/55))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Enhancements
-- (docker) added `APP_VERSION` and `BUILD_STATUS` build args to stamp `constants.js` at image build time — pass `BUILD_STATUS=$(git rev-parse --short HEAD)` to identify the exact build running in the PWA
+- (docker) added support for `APP_VERSION` and `BUILD_STATUS` build args to stamp app at image build time. Build example: `BUILD_STATUS=$(git rev-parse --short HEAD)` ([#57](https://github.com/isolinear-labs/Neosynth/pull/57))
 
 ### Bug Fixes
 - (frontend/resume) fixed mobile Resume playing from the wrong track/position — playlist now loads directly on the saved track, seeks before `play()` is called, resulting in a much smoother Resume experience ([#55](https://github.com/isolinear-labs/Neosynth/pull/55))

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM node:22-alpine
 
+# Optional build-time overrides — pass with:
+#   docker build --build-arg APP_VERSION=1.2.3 --build-arg BUILD_STATUS=$(git rev-parse --short HEAD) ...
+ARG APP_VERSION
+ARG BUILD_STATUS
+
 # Add container labels for GitHub Container Registry
 LABEL org.opencontainers.image.source="https://github.com/isolinear-labs/Neosynth"
 LABEL org.opencontainers.image.description="NeoSynth - A cyberpunk-themed music and video stream application."
@@ -15,6 +20,14 @@ RUN cd /app/backend && npm install
 # Copy application code
 COPY backend/ /app/backend/
 COPY frontend/ /app/frontend/
+
+# Stamp constants.js with build-time values if supplied
+RUN if [ -n "$APP_VERSION" ]; then \
+        sed -i "s/export const VERSION = '[^']*'/export const VERSION = '$APP_VERSION'/" /app/frontend/constants.js; \
+    fi && \
+    if [ -n "$BUILD_STATUS" ]; then \
+        sed -i "s/export const BUILD_STATUS = '[^']*'/export const BUILD_STATUS = '$BUILD_STATUS'/" /app/frontend/constants.js; \
+    fi
 
 # Validate the frontend content is copied correctly
 RUN ls -la /app/frontend


### PR DESCRIPTION
## Description
This PR adds support for passing `APP_VERSION` and `BUILD_STATUS`  build vars through Docker builds. 

## Reason for PR
- [x] New feature
- [ ] Enhancement
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring

## Breaking change?
- [ ] Yes

