### PR TITLE
(feat): Add Support for Client Error Logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Enhancements
+- feat(frontend/mobile): Added `client_error_logging` feature flag and client logger module — captures audio interruption and page lifecycle events (visibility, freeze, pagehide) and forwards them to the backend log via `sendBeacon` for iOS PWA debugging
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Enhancements
-- feat(frontend/mobile): Added `client_error_logging` feature flag and client logger module — captures audio interruption and page lifecycle events (visibility, freeze, pagehide) and forwards them to the backend log via `sendBeacon` for iOS PWA debugging
+- feat(frontend/mobile): Added `client_error_logging` feature flag and client logger module — captures audio interruption and page lifecycle events and forwards them to the backend logs ([#81](https://github.com/isolinear-labs/Neosynth/pull/81))
 
 ### Bug Fixes
 

--- a/backend/routes/clientLog.js
+++ b/backend/routes/clientLog.js
@@ -13,7 +13,6 @@ const clientLogLimit = rateLimit({
 
 const ALLOWED_EVENTS = [
     'visibility_hidden',
-    'visibility_visible',
     'page_freeze',
     'page_hide',
     'audio_interrupted',

--- a/backend/routes/clientLog.js
+++ b/backend/routes/clientLog.js
@@ -1,0 +1,82 @@
+const express = require('express');
+const router = express.Router();
+const rateLimit = require('express-rate-limit');
+const Joi = require('joi');
+
+const clientLogLimit = rateLimit({
+    windowMs: 1 * 60 * 1000,
+    limit: 30,
+    message: { message: 'Too many log requests' },
+    standardHeaders: true,
+    legacyHeaders: false
+});
+
+const ALLOWED_EVENTS = [
+    'visibility_hidden',
+    'visibility_visible',
+    'page_freeze',
+    'page_hide',
+    'audio_interrupted',
+    'audio_context_state_change',
+    'playback_error'
+];
+
+const clientLogSchema = Joi.object({
+    event: Joi.string().valid(...ALLOWED_EVENTS).required(),
+    timestamp: Joi.string().isoDate().required(),
+    platform: Joi.object({
+        userAgent: Joi.string().max(500).required(),
+        isIOS: Joi.boolean().required(),
+        isPWA: Joi.boolean().required(),
+        iosVersion: Joi.string().max(20).allow(null).optional()
+    }).required(),
+    playback: Joi.object({
+        isPlaying: Joi.boolean().required(),
+        currentTime: Joi.number().allow(null).optional(),
+        duration: Joi.number().allow(null).optional(),
+        track: Joi.string().max(500).allow(null).optional()
+    }).optional(),
+    audioContextState: Joi.string().max(50).optional(),
+    source: Joi.string().max(100).optional(),
+    persisted: Joi.boolean().optional(),
+    errCode: Joi.number().integer().min(1).max(4).allow(null).optional(),
+    errName: Joi.string().max(50).optional(),
+    errMessage: Joi.string().max(500).allow(null).optional(),
+    failedUrl: Joi.string().max(1000).allow(null).optional()
+});
+
+router.post('/client-log', clientLogLimit, (req, res) => {
+    const { error, value } = clientLogSchema.validate(req.body, { stripUnknown: true });
+    if (error) {
+        return res.status(400).json({ message: 'Invalid log payload' });
+    }
+
+    const { event, timestamp, platform, playback, audioContextState, source, errCode, errName, errMessage, failedUrl } = value;
+
+    const parts = [
+        '[CLIENT-LOG]',
+        `event=${event}`,
+        `ts=${timestamp}`,
+        `ios=${platform.isIOS}`,
+        `pwa=${platform.isPWA}`
+    ];
+
+    if (platform.iosVersion) parts.push(`ios_ver=${platform.iosVersion}`);
+    if (playback) {
+        parts.push(`playing=${playback.isPlaying}`);
+        if (playback.currentTime != null) parts.push(`pos=${Math.round(playback.currentTime)}s`);
+        if (playback.track) parts.push(`track=${playback.track}`);
+    }
+    if (audioContextState) parts.push(`ctx=${audioContextState}`);
+    if (source) parts.push(`src=${source}`);
+    if (errCode != null) parts.push(`err_code=${errCode}`);
+    if (errName) parts.push(`err_name=${errName}`);
+    if (errMessage) parts.push(`err_msg=${errMessage}`);
+    if (failedUrl) parts.push(`failed_url=${failedUrl}`);
+
+    console.log(parts.join(' | '));
+
+    res.status(204).end();
+});
+
+module.exports = router;

--- a/backend/routes/clientLog.js
+++ b/backend/routes/clientLog.js
@@ -12,7 +12,6 @@ const clientLogLimit = rateLimit({
 });
 
 const ALLOWED_EVENTS = [
-    'visibility_hidden',
     'page_freeze',
     'page_hide',
     'audio_interrupted',

--- a/backend/routes/featureFlags.js
+++ b/backend/routes/featureFlags.js
@@ -664,6 +664,14 @@ router.get('/admin/discovery/categories', UnifiedAuth.authenticate, UnifiedAuth.
                 templates: [
                     ...(appFeatureCategories['developer'] || []),
                     {
+                        id: 'client_error_logging',
+                        name: 'Client Error Logging',
+                        description: 'Forward client-side audio interruptions, playback errors, and page lifecycle events to the backend log for debugging (uses sendBeacon — survives page teardown)',
+                        category: 'developer',
+                        adminOnly: false,
+                        metadata: { frontend: true, location: 'modules/clientLogger/clientLogger.js' }
+                    },
+                    {
                         id: 'console_debug_logging',
                         name: 'Console Debug Logging',
                         description: 'Enable verbose console logging for debugging frontend modules',

--- a/backend/server.js
+++ b/backend/server.js
@@ -22,6 +22,7 @@ const trackRoutes = require('./routes/tracks');
 const userRoutes = require('./routes/users');
 const apiKeyRoutes = require('./routes/apiKeys');
 const featureFlagRoutes = require('./routes/featureFlags');
+const clientLogRoutes = require('./routes/clientLog');
 const { generateAssetHashes } = require('./utils/assetHasher');
 
 
@@ -314,6 +315,7 @@ app.use('/api/tracks', trackRoutes);
 app.use('/api', nowPlayingRoutes);
 app.use('/api/keys', apiKeyRoutes);
 app.use('/api', featureFlagRoutes);
+app.use('/api', clientLogRoutes);
 
 
 

--- a/frontend/modules/clientLogger/clientLogger.js
+++ b/frontend/modules/clientLogger/clientLogger.js
@@ -1,0 +1,137 @@
+// @feature-flag: client_error_logging
+// @description: Send client-side audio lifecycle events to the backend for debugging
+// @category: developer
+
+class ClientLogger {
+    constructor() {
+        this.appElements = null;
+        this.endpoint = '/api/client-log';
+        // Lifecycle listeners run on all platforms at module load time
+        this._setupLifecycleListeners();
+    }
+
+    // Wire in playback context — called from AudioInterruptionManager.init() on mobile,
+    // giving richer log output (track, position, isPlaying) when available
+    init(appElements) {
+        this.appElements = appElements;
+    }
+
+    isEnabled() {
+        try {
+            return window.featureManager?.isEnabled('client_error_logging') ?? false;
+        } catch {
+            return false;
+        }
+    }
+
+    _getContext() {
+        const ua = navigator.userAgent;
+        const isIOS = /iPhone|iPad|iPod/.test(ua);
+        const isPWA = navigator.standalone === true;
+
+        let iosVersion = null;
+        if (isIOS) {
+            const match = ua.match(/OS (\d+)[._](\d+)/);
+            if (match) iosVersion = `${match[1]}.${match[2]}`;
+        }
+
+        const ctx = {
+            timestamp: new Date().toISOString(),
+            platform: { userAgent: ua, isIOS, isPWA, iosVersion }
+        };
+
+        if (this.appElements) {
+            const player = this.appElements.currentPlayer;
+            ctx.playback = {
+                isPlaying: this.appElements.isPlaying ?? false,
+                currentTime: player?.currentTime ?? null,
+                duration: player?.duration ?? null,
+                // Only send filename, not full URL
+                track: player?.src ? decodeURIComponent(player.src.split('/').pop().split('?')[0]) : null
+            };
+        }
+
+        return ctx;
+    }
+
+    send(event, extra = {}) {
+        if (!this.isEnabled()) return;
+
+        const payload = { event, ...this._getContext(), ...extra };
+        const data = JSON.stringify(payload);
+
+        // sendBeacon is preferred — survives page teardown (iOS suspension, tab kill)
+        if (navigator.sendBeacon) {
+            const blob = new Blob([data], { type: 'application/json' });
+            navigator.sendBeacon(this.endpoint, blob);
+        } else {
+            fetch(this.endpoint, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: data,
+                keepalive: true
+            }).catch(() => {});
+        }
+    }
+
+    _setupLifecycleListeners() {
+        document.addEventListener('visibilitychange', () => {
+            if (document.hidden) {
+                this.send('visibility_hidden');
+            } else {
+                this.send('visibility_visible');
+            }
+        });
+
+        // Page Lifecycle API — fires just before the browser freezes/suspends the page (iOS PWA)
+        window.addEventListener('freeze', () => {
+            this.send('page_freeze');
+        });
+
+        // pagehide is more reliable than beforeunload on mobile Safari
+        window.addEventListener('pagehide', (e) => {
+            this.send('page_hide', { persisted: e.persisted });
+        });
+    }
+
+    logAudioInterruption(source) {
+        this.send('audio_interrupted', { source });
+    }
+
+    logAudioContextChange(state) {
+        this.send('audio_context_state_change', { audioContextState: state });
+    }
+
+    logPlaybackError(mediaError, failedSrc = null) {
+        const ERROR_NAMES = {
+            1: 'MEDIA_ERR_ABORTED',
+            2: 'MEDIA_ERR_NETWORK',
+            3: 'MEDIA_ERR_DECODE',
+            4: 'MEDIA_ERR_SRC_NOT_SUPPORTED'
+        };
+        // Strip origin so we log the path only (e.g. /api/tracks/stream/artist/song.mp3)
+        let failedUrl = null;
+        if (failedSrc) {
+            try {
+                const url = new URL(failedSrc);
+                failedUrl = decodeURIComponent(url.pathname + url.search);
+            } catch {
+                failedUrl = failedSrc;
+            }
+        }
+        this.send('playback_error', {
+            errCode: mediaError?.code ?? null,
+            errName: ERROR_NAMES[mediaError?.code] ?? 'UNKNOWN',
+            errMessage: mediaError?.message ?? null,
+            failedUrl
+        });
+    }
+}
+
+const clientLogger = new ClientLogger();
+
+if (typeof window !== 'undefined') {
+    window.clientLogger = clientLogger;
+}
+
+export default clientLogger;

--- a/frontend/modules/clientLogger/clientLogger.js
+++ b/frontend/modules/clientLogger/clientLogger.js
@@ -78,8 +78,6 @@ class ClientLogger {
         document.addEventListener('visibilitychange', () => {
             if (document.hidden) {
                 this.send('visibility_hidden');
-            } else {
-                this.send('visibility_visible');
             }
         });
 

--- a/frontend/modules/clientLogger/clientLogger.js
+++ b/frontend/modules/clientLogger/clientLogger.js
@@ -75,12 +75,6 @@ class ClientLogger {
     }
 
     _setupLifecycleListeners() {
-        document.addEventListener('visibilitychange', () => {
-            if (document.hidden) {
-                this.send('visibility_hidden');
-            }
-        });
-
         // Page Lifecycle API — fires just before the browser freezes/suspends the page (iOS PWA)
         window.addEventListener('freeze', () => {
             this.send('page_freeze');

--- a/frontend/modules/mobile/audioInterruption.js
+++ b/frontend/modules/mobile/audioInterruption.js
@@ -1,4 +1,5 @@
 import debug from '../debugLogger/debugLogger.js';
+import clientLogger from '../clientLogger/clientLogger.js';
 
 export class AudioInterruptionManager {
     constructor() {
@@ -12,6 +13,7 @@ export class AudioInterruptionManager {
 
     init(appElements) {
         this.appElements = appElements;
+        clientLogger.init(appElements);
         this.setupInterruptionHandlers();
         this.setupAudioContextHandling();
         this.setupVisibilityHandling();
@@ -29,6 +31,7 @@ export class AudioInterruptionManager {
             // Handle audio context state changes
             audioContext.addEventListener('statechange', () => {
                 console.log('Audio context state changed:', audioContext.state);
+                clientLogger.logAudioContextChange(audioContext.state);
                 if (audioContext.state === 'suspended') {
                     this.handleAudioInterruption();
                 } else if (audioContext.state === 'running') {
@@ -60,6 +63,7 @@ export class AudioInterruptionManager {
                     this._pauseInterruptionTimer = setTimeout(() => {
                         if (this.appElements.currentPlayer?.paused && this.appElements.isPlaying && !this.isHandlingInterruption) {
                             debug.log('Audio paused unexpectedly - possible interruption');
+                            clientLogger.logAudioInterruption('unexpected_pause');
                             this.handleAudioInterruption();
                         }
                     }, 800);
@@ -105,6 +109,14 @@ export class AudioInterruptionManager {
             audioPlayer.addEventListener('playing', () => {
                 clearTimeout(this._stalledInterruptionTimer);
                 clearTimeout(this._waitingInterruptionTimer);
+            });
+
+            audioPlayer.addEventListener('error', () => {
+                if (audioPlayer.error && !this.appElements.isIntentionalStop) {
+                    // Snapshot src immediately — checkAndRefreshAudio() clears it during recovery
+                    const failedSrc = audioPlayer.src || this.currentTrackUrl || null;
+                    clientLogger.logPlaybackError(audioPlayer.error, failedSrc);
+                }
             });
         }
 

--- a/frontend/modules/mobile/init.js
+++ b/frontend/modules/mobile/init.js
@@ -32,7 +32,7 @@ export async function initMobile(appScope, showStatus) {
         mediaSession.init(appElements),
         mobileOptimizations.init(appElements, statePersistence)
     ]);
-	
+
     // Return object with methods that can be called from main app
     return {
         statePersistence,


### PR DESCRIPTION
## Description
This PR adds support for a logging from the client side. Client browser side errors normally are not captured in logs, preventing troubleshooting for certain scenarios. Enabling this feature allows client errors to be streamed to the backend logs. 

## Reason for PR
- [x] New feature
- [ ] Enhancement
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring

## Breaking change?
- [ ] Yes

## User Impact & Considerations
None. 

<!-- You may remove the below options if deemed unessary -->