### PR TITLE
(backend/featureFlags) Replace deprecated Mongoose fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 ### Bug Fixes
+- (backend/featureFlags) Replace deprecated `new: true` with `returnDocument: 'after'` in `findByIdAndUpdate` for Mongoose 9.6.1 compatibility ([#85](https://github.com/isolinear-labs/Neosynth/pull/85))
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Enhancements
 
 ### Bug Fixes
-- (backend/featureFlags) Replace deprecated `new: true` with `returnDocument: 'after'` in `findByIdAndUpdate` for Mongoose 9.6.1 compatibility ([#85](https://github.com/isolinear-labs/Neosynth/pull/85))
+- (backend/featureFlags) Replace deprecated `new: true` with `returnDocument: 'after'` in `findByIdAndUpdate` for Mongoose 9.6.1 compatibility ([#88](https://github.com/isolinear-labs/Neosynth/pull/88))
 
 ### Docs
 

--- a/backend/routes/featureFlags.js
+++ b/backend/routes/featureFlags.js
@@ -545,7 +545,7 @@ router.put('/admin/feature-flags/:id', async (req, res) => {
         const flag = await FeatureFlag.findByIdAndUpdate(
             req.params.id,
             updateData,
-            { new: true }
+            { returnDocument: 'after' }
         );
         
         if (!flag) {


### PR DESCRIPTION
## Description
This PR replaces a deprecated reference of  `new: true` with `returnDocument: 'after'` in `findByIdAndUpdate` for Mongoose 9.6.1 compatibility.

## Reason for PR
- [ ] New feature
- [ ] Enhancement
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring

## Breaking change?
- [ ] Yes

## User Impact & Considerations
None

<!-- You may remove the below options if deemed unessary -->