### PR TITLE
build(deps): patch js-yaml and brace-expansion CVEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Bump `sanitize-html` from 2.17.4 to 2.17.5 ([#97](https://github.com/isolinear-labs/Neosynth/pull/97))
 - Bump `eslint` from 10.4.1 to 10.5.0 ([#96](https://github.com/isolinear-labs/Neosynth/pull/96), [#95](https://github.com/isolinear-labs/Neosynth/pull/95))
 - Bump `form-data` from 4.0.5 to 4.0.6 ([#98](https://github.com/isolinear-labs/Neosynth/pull/98))
+- Bump `js-yaml` from 4.1.0 to 4.2.0 — resolves CVE-2026-53550 (moderate DoS; pinned via `overrides` to also patch the transitive copy from `jest`)
+- Bump `brace-expansion` from 5.0.5 to 5.0.6 — resolves CVE-2026-45149 (ReDoS)
 
 ## [v1.2.1] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@
 - Bump `sanitize-html` from 2.17.4 to 2.17.5 ([#97](https://github.com/isolinear-labs/Neosynth/pull/97))
 - Bump `eslint` from 10.4.1 to 10.5.0 ([#96](https://github.com/isolinear-labs/Neosynth/pull/96), [#95](https://github.com/isolinear-labs/Neosynth/pull/95))
 - Bump `form-data` from 4.0.5 to 4.0.6 ([#98](https://github.com/isolinear-labs/Neosynth/pull/98))
-- Bump `js-yaml` from 4.1.0 to 4.2.0 — resolves CVE-2026-53550 (moderate DoS; pinned via `overrides` to also patch the transitive copy from `jest`)
-- Bump `brace-expansion` from 5.0.5 to 5.0.6 — resolves CVE-2026-45149 (ReDoS)
+- Bump `js-yaml` from 4.1.0 to 4.2.0 — resolves CVE-2026-53550 (moderate DoS; pinned via `overrides` to also patch the transitive copy from `jest`) ([#99](https://github.com/isolinear-labs/Neosynth/pull/99))
+- Bump `brace-expansion` from 5.0.5 to 5.0.6 — resolves CVE-2026-45149 (ReDoS) ([#99](https://github.com/isolinear-labs/Neosynth/pull/99))
 
 ## [v1.2.1] - 2026-06-04
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,7 +17,7 @@
                 "helmet": "^8.2.0",
                 "ip-range-check": "^0.2.0",
                 "joi": "^18.2.1",
-                "js-yaml": "^4.1.0",
+                "js-yaml": "^4.2.0",
                 "mongoose": "^9.7.0",
                 "qrcode": "^1.5.3",
                 "sanitize-html": "^2.17.5",
@@ -839,16 +839,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "sprintf-js": "~1.0.2"
-            }
-        },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -861,20 +851,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-            "version": "3.14.2",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-            "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
@@ -3177,20 +3153,6 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/esprima": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "bin": {
-                "esparse": "bin/esparse.js",
-                "esvalidate": "bin/esvalidate.js"
-            },
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/esquery": {
@@ -6487,13 +6449,6 @@
             "engines": {
                 "node": ">= 0.10.0"
             }
-        },
-        "node_modules/sprintf-js": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-            "dev": true,
-            "license": "BSD-3-Clause"
         },
         "node_modules/stack-utils": {
             "version": "2.0.6",

--- a/backend/package.json
+++ b/backend/package.json
@@ -24,7 +24,7 @@
         "helmet": "^8.2.0",
         "ip-range-check": "^0.2.0",
         "joi": "^18.2.1",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.2.0",
         "mongoose": "^9.7.0",
         "qrcode": "^1.5.3",
         "sanitize-html": "^2.17.5",
@@ -37,6 +37,9 @@
         "jest": "^30.4.2",
         "nodemon": "^3.1.14",
         "supertest": "^7.2.2"
+    },
+    "overrides": {
+        "js-yaml": "^4.2.0"
     },
     "jest": {
         "testEnvironment": "node",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -256,9 +256,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {


### PR DESCRIPTION
## Description
This PR resolves two moderate npm audit findings:

  - backend: pin js-yaml to ^4.2.0 via package.json `overrides` to patch the transitive 3.14.2 copy pulled in through jest. Fixes CVE-2026-53550 (GHSA-h67p-54hq-rp68) — quadratic-complexity DoS in merge-key handling.
  - frontend: bump brace-expansion 5.0.5 -> 5.0.6 (npm audit fix). Fixes CVE-2026-45149 (GHSA-jxxr-4gwj-5jf2) — ReDoS.


<!-- Provide a brief description of the changes in this PR as well as a reason for this update -->

## Reason for PR
- [ ] New feature
- [ ] Enhancement
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring

## Breaking change?
- [ ] Yes

## User Impact & Considerations
N/A
