### PR TITLE
fix: bump js-yaml and postcss overrides to clear moderate/high audit …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Bump `helmet` from 8.2.0 to 8.3.0 ([#114](https://github.com/isolinear-labs/Neosynth/pull/114))
 - Bump `mongoose` from 9.7.3 to 9.7.4 ([#114](https://github.com/isolinear-labs/Neosynth/pull/114))
 - Bump `sanitize-html` from 2.17.5 to 2.17.6 ([#114](https://github.com/isolinear-labs/Neosynth/pull/114))
+- Bump `js-yaml` from 4.2.0 to 4.3.0 — resolves CVE affecting merge-key chains (moderate DoS; pinned via `overrides`, same pattern as #99) ([#122](https://github.com/isolinear-labs/Neosynth/pull/122))
+- Bump `postcss` (transitive, via `sanitize-html`) from 8.5.15 to 8.5.18 via `overrides` — resolves GHSA-r28c-9q8g-f849 (sourcemap path traversal) ([#122](https://github.com/isolinear-labs/Neosynth/pull/122))
 
 ## [v1.2.2] - 2026-07-08
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,7 +17,7 @@
                 "helmet": "^8.3.0",
                 "ip-range-check": "^0.2.0",
                 "joi": "^18.2.3",
-                "js-yaml": "^4.2.0",
+                "js-yaml": "^4.3.0",
                 "mongoose": "^9.7.4",
                 "qrcode": "^1.5.3",
                 "sanitize-html": "^2.17.6",
@@ -4706,9 +4706,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
             "funding": [
                 {
                     "type": "github",
@@ -5138,9 +5138,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.12",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
             "funding": [
                 {
                     "type": "github",
@@ -5641,9 +5641,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.15",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-            "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+            "version": "8.5.23",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+            "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -5660,7 +5660,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.12",
+                "nanoid": "^3.3.16",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },

--- a/backend/package.json
+++ b/backend/package.json
@@ -24,7 +24,7 @@
         "helmet": "^8.3.0",
         "ip-range-check": "^0.2.0",
         "joi": "^18.2.3",
-        "js-yaml": "^4.2.0",
+        "js-yaml": "^4.3.0",
         "mongoose": "^9.7.4",
         "qrcode": "^1.5.3",
         "sanitize-html": "^2.17.6",
@@ -39,8 +39,9 @@
         "supertest": "^7.2.2"
     },
     "overrides": {
-        "js-yaml": "^4.2.0",
-        "htmlparser2": "^10.1.0"
+        "js-yaml": "^4.3.0",
+        "htmlparser2": "^10.1.0",
+        "postcss": "^8.5.18"
     },
     "jest": {
         "testEnvironment": "node",


### PR DESCRIPTION
## Description
Two dependencies flagged by npm audit were out of date and blocking the security audit check on CI:

- js-yaml → bumped to 4.3.0 (fixes a CPU exhaustion issue)
- postcss → bumped to 8.5.18 (fixes a path traversal issue)

## Reason for PR
- [ ] New feature
- [ ] Enhancement
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring

## Breaking change?
- [ ] Yes
