### PR TITLE
Bumps `nanoid` `3.3.16` → `3.3.18` in `backend/package-lock.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Docs
 
 ### Dependencies
+- Bump `nanoid` (transitive, via `sanitize-html` -> `postcss`) from 3.3.16 to 3.3.18 — resolves GHSA-2v37-7h3g-55p8 (high severity DoS: custom generators can loop indefinitely when `size` is zero) ([#137](https://github.com/isolinear-labs/Neosynth/pull/137))
 
 ## [v1.2.3] - 2026-08-06
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -5152,9 +5152,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.16",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+            "version": "3.3.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
             "funding": [
                 {
                     "type": "github",


### PR DESCRIPTION
## Description
Bumps nanoid 3.3.16 → 3.3.18 in backend/package-lock.json, resolving GHSA-2v37-7h3g-55p8

## Reason for PR
- [ ] New feature
- [ ] Enhancement
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring

## Breaking change?
- [ ] Yes

## User Impact & Considerations
<!-- Describe any potential user impact or items that other should be aware of -->

<!-- You may remove the below options if deemed unessary -->

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Related Issue (if applicable)
<!-- Use keywords to auto-close: Closes #123, Fixes #456, Resolves #789 -->
<!-- Or just reference: Related to #123, See #456 -->

